### PR TITLE
Update openapi yaml to use new bearer auth

### DIFF
--- a/ecx2-openapi.yaml
+++ b/ecx2-openapi.yaml
@@ -2283,8 +2283,7 @@ components:
 
     securitySchemes:
       api_key:
-        type: apiKey
-        name: Authorization
-        in: header
+        type: http
+        scheme: bearer
         description: This API uses a http Header "Authentication" that contains a "Bearer <api_key>" value
-      
+  


### PR DESCRIPTION
# Background
ECrimeX has moved to their new API

# Context
Authentication has been updated from API token to Bearer Auth token. The Swagger docs have not been updated with the change so test executions and sample curl commands are not working.

# Solution
Update Swagger docs to use Bearer auth